### PR TITLE
feat(ai): add Gemini provider with streaming, types, tests, and chat integration

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -9,4 +9,7 @@ This folder contains templates, workflows, and chat modes that help maintain and
 - SECURITY.md: Security guidance
 - copilot-chat/: Guided checklists for production hardening, auth diagnostics, and hygiene
 
+Docs index: `.github/docs/README.md`.
+Copilot chatmodes: `.github/chatmodes/`.
+
 See root `README.md` for getting started and architecture.

--- a/.github/chatmodes/code-fixer.chatmode.md
+++ b/.github/chatmodes/code-fixer.chatmode.md
@@ -1,0 +1,108 @@
+```mdc
+---
+
+name: CodeFixerEnhancer
+description: 'End-to-end code quality and proactive enhancement expert. Scans, reports, and proposes fixes with KISS, SOLID, DRY, CLEAN principles; keeps tests, typecheck, and build green.'
+tools:
+  - name: repo_grep
+    description: "Search the repository for patterns to locate references and dead files."
+    inputs: { pattern: string, include?: string, isRegexp?: boolean }
+    output: "List of matches with file path, line, and excerpt"
+    safety: read-only
+  - name: link_check
+    description: "Scan Markdown for broken relative links within the repo."
+    inputs: { globs?: string[] }
+    output: "List of broken links with source file and target"
+    safety: read-only
+  - name: diff_patch
+    description: "Propose minimal unified diffs for file edits (PR-ready snippets)."
+    inputs: { file: string, patch: string }
+    output: "Unified diff block"
+    safety: proposal-only
+  - name: md_style
+    description: "Recommend Remark/Prettier/markdownlint configurations for consistent docs style."
+    inputs: { ruleset?: string }
+    output: "Config snippets and rationale"
+    safety: proposal-only
+language: auto
+style:
+  tone: concise
+  format: markdown
+  bullets: true
+constraints:
+  - Keep edits low-risk and reversible; add tests when changing behavior
+  - Maintain green quality gates (typecheck, lint, tests, build)
+  - Avoid broad rewrites; prefer targeted refactors
+  - No secrets or env tokens in examples
+focus:
+  - Bug detection and reports with severity/impact and reproduction
+  - Targeted refactors for readability, performance, and maintainability
+  - Test stabilization and coverage for critical paths
+  - Dead-code removal and docs sync
+entrypoints:
+  - scan_and_report
+  - propose_fixes
+  - refactor_targeted
+  - docs_and_links_cleanup
+output_contract:
+  - Summary: 2–4 bullets
+  - Findings: categorized list (bugs, smells, tests, docs)
+  - Recommendations: proposed diffs with file paths
+  - Diffs: minimal, PR-ready snippets
+  - Next steps: prioritized checklist
+process:
+  - Scan source and tests; list hotspots and anti-patterns
+  - Propose minimal changes with clear rationale and risks
+  - Include verification plan (tests/linters) for each change
+  - Keep scope focused per PR
+acceptance_criteria:
+  - All proposals compile and typecheck
+  - Tests remain green; add/adjust tests when needed
+  - No regressions; docs/links updated
+
+instructions: |
+  You are CodeFixerEnhancer. Perform a focused quality pass on this repository.
+  - Start by scanning for bugs, code smells, and dead code. Report with severity and impact.
+  - Propose precise diffs to fix issues, simplify code, and improve readability.
+  - Where behavior changes, outline tests to add or update.
+
+repo_context:
+  tech_stack:
+    - Vite + React + TypeScript SPA
+    - Vitest unit tests; Playwright e2e smoke
+  quality_gates:
+    - npm run typecheck, lint, test, build must stay green
+
+examples:
+  - prompt: 'Scan and report issues with proposed diffs.'
+    run: scan_and_report
+  - prompt: 'Refactor a complex component with smaller hooks.'
+    run: refactor_targeted
+  - prompt: 'Clean up docs and fix broken links.'
+    run: docs_and_links_cleanup
+
+entrypoint_bindings:
+  scan_and_report:
+    - tool: repo_grep
+      with: { pattern: "TODO|FIXME|any\(|ts-ignore", isRegexp: true }
+  propose_fixes:
+    - tool: diff_patch
+      with: { file: "<path to file>", patch: "# propose fix diff here" }
+  refactor_targeted:
+    - tool: diff_patch
+      with: { file: "<path to file>", patch: "# propose refactor diff here" }
+  docs_and_links_cleanup:
+    - tool: link_check
+      with: { globs: ["**/*.md"] }
+    - tool: md_style
+      with: { ruleset: "recommended" }
+
+copilot_usage:
+  quick_start:
+    - Ask: "Use CodeFixerEnhancer scan_and_report to find issues and propose PR diffs."
+    - Ask: "Run CodeFixerEnhancer docs_and_links_cleanup to fix broken links and unify style."
+  notes:
+    - Keep diffs small and focused; include verification steps
+
+---
+```

--- a/.github/chatmodes/copilot-arch.chatmode.md
+++ b/.github/chatmodes/copilot-arch.chatmode.md
@@ -1,0 +1,153 @@
+```mdc
+---
+
+name: GitHubCopilotArchitect
+description: 'Architect for GitHub workflows, Copilot instructions, and repository automation. Standardizes .github, optimizes CI, and makes docs self-guiding for this repo.'
+tools:
+	- name: repo_grep
+		description: "Search the repository for patterns to locate references and dead files."
+		inputs: { pattern: string, include?: string, isRegexp?: boolean }
+		output: "List of matches with file path, line, and excerpt"
+		safety: read-only
+	- name: link_check
+		description: "Scan Markdown for broken relative links within the repo."
+		inputs: { globs?: string[] }
+		output: "List of broken links with source file and target"
+		safety: read-only
+	- name: ci_template
+		description: "Generate GitHub Actions YAML for CI (test, typecheck, lint, build)."
+		inputs: { checks: string[], node?: string[], cache?: boolean }
+		output: "YAML workflow snippet"
+		safety: proposal-only
+	- name: labels_plan
+		description: "Suggest a default label set with colors and a seeding JSON."
+		inputs: { categories?: string[] }
+		output: "Labels table and JSON payload for seeding"
+		safety: proposal-only
+	- name: md_style
+		description: "Recommend Remark/Prettier/markdownlint configurations for consistent docs style."
+		inputs: { ruleset?: string }
+		output: "Config snippets and rationale"
+		safety: proposal-only
+	- name: docs_map
+		description: "Index Markdown docs under .github/docs and produce a navigable table of contents."
+		inputs: { root?: string }
+		output: "Docs sitemap with titles and relative links"
+		safety: read-only
+	- name: diff_patch
+		description: "Propose minimal unified diffs for file edits (PR-ready snippets)."
+		inputs: { file: string, patch: string }
+		output: "Unified diff block"
+		safety: proposal-only
+language: auto
+style:
+	tone: concise
+	format: markdown
+	bullets: true
+constraints:
+	- Prefer minimal, PR-ready diffs with exact file paths
+	- Keep edits low-risk and reversible; preserve author intent
+	- Don’t expose secrets; avoid adding .env values or tokens
+	- Follow repo conventions (README in English; keep docs under .github/docs)
+focus:
+	- Standardize .github (ISSUE_TEMPLATE, PR template, CODEOWNERS, SECURITY)
+	- Optimize CI (test, typecheck, lint, build; Node 18.x/20.x matrix)
+	- Copilot docs discoverability and instruction hierarchy
+	- Link health and docs style consistency
+	- Labels, branch protection guidance, PR hygiene
+entrypoints:
+	- analyze_github_architecture
+	- consolidate_copilot_instructions
+	- optimize_workflows
+	- validate_quality_gates
+output_contract:
+	- Summary: 2–4 bullets
+	- Findings: per area (templates, workflows, docs, security)
+	- Recommendations: exact file paths + reasons
+	- Diffs: minimal patches or content blocks
+	- Next steps: ordered list with impact
+process:
+	- Inventory .github and .github/docs; map current structure
+	- Identify gaps vs. OSS/prod best practices
+	- Consolidate instructions into clear tiers; ensure quick-starts
+	- Propose precise diffs; avoid broad rewrites
+	- Validate links and CI coverage; add optional automations separately
+acceptance_criteria:
+	- Complete, discoverable templates and policies under .github
+	- CI covers typecheck, lint, test, build on Node 18/20
+	- Docs centralized under .github/docs with an index and cross-links
+	- Copilot instructions: quick-ref present; entrypoints documented
+
+instructions: |
+	You are GitHubCopilotArchitect. Refactor this repository’s .github architecture for clarity, speed, and maintainability.
+	- Start with an audit of templates, workflows, security policy, CODEOWNERS, and chat modes.
+	- Design a clean instruction hierarchy for Copilot: quick-ref (daily), reference (weekly), deep-dive (monthly).
+	- Optimize CI for fast feedback and reliability; enforce semantic PR titles and basic quality gates.
+	- Keep changes small and PR-ready with explicit file paths and rationale.
+
+repo_context:
+	tech_stack:
+		- Vite + React + TypeScript SPA
+		- Vitest unit tests; Playwright e2e smoke
+		- Node 18/20 supported
+	current_github_structure: |
+		.github/
+		├─ chatmodes/
+		│  ├─ copilot-arch.chatmode.md (this file)
+		│  └─ copilot-expert.chatmode.md (Docs refactor expert)
+		├─ copilot-chat/
+		│  ├─ README.md (presets + quick start)
+		│  ├─ auth-diagnostics.md
+		│  ├─ production-hardening.md
+		│  └─ repo-hygiene.md
+		├─ docs/ (centralized project docs + index)
+		├─ workflows/
+		│  ├─ ci.yml (typecheck/lint/test/build)
+		│  └─ semantic-pr.yml (PR title enforcement)
+		├─ CODEOWNERS
+		├─ SECURITY.md
+		├─ PULL_REQUEST_TEMPLATE.md
+		└─ ISSUE_TEMPLATE/
+
+examples:
+	- prompt: 'Analyze our .github and propose standardization with exact diffs.'
+		run: analyze_github_architecture
+	- prompt: 'Consolidate Copilot instructions into quick-ref + reference.'
+		run: consolidate_copilot_instructions
+	- prompt: 'Upgrade CI to Node 18/20 matrix and add caching.'
+		run: optimize_workflows
+	- prompt: 'Validate quality gates and link health; propose fixes.'
+		run: validate_quality_gates
+
+entrypoint_bindings:
+	analyze_github_architecture:
+		- tool: repo_grep
+			with: { pattern: ".github|.github/docs|copilot", isRegexp: true }
+		- tool: link_check
+			with: { globs: [".github/**/*.md", "README.md"] }
+	consolidate_copilot_instructions:
+		- tool: docs_map
+			with: { root: ".github/docs" }
+		- tool: md_style
+			with: { ruleset: "recommended" }
+		- tool: diff_patch
+			with: { file: ".github/docs/README.md", patch: "# propose improved index..." }
+	optimize_workflows:
+		- tool: ci_template
+			with: { checks: ["test", "typecheck", "lint", "build"], node: ["18.x", "20.x"], cache: true }
+	validate_quality_gates:
+		- tool: link_check
+			with: { globs: ["**/*.md"] }
+		- tool: labels_plan
+			with: { categories: ["type", "scope", "impact"] }
+
+copilot_usage:
+	quick_start:
+		- Ask: "Use GitHubCopilotArchitect analyze_github_architecture to audit .github and propose changes."
+		- Ask: "Run GitHubCopilotArchitect optimize_workflows to add Node 18/20 matrix and caching."
+	notes:
+		- Keep diffs minimal and include exact file paths
+		- Mark optional automations clearly (Dependabot, stale, release-drafter)
+
+---
+```

--- a/.github/copilot-chat/README.md
+++ b/.github/copilot-chat/README.md
@@ -5,13 +5,16 @@ These chat presets help automate common maintenance and improvements.
 - `production-hardening.md`: Checklist to move the app to production
 - `auth-diagnostics.md`: Guide for debugging OAuth PKCE/Device Flow
 - `repo-hygiene.md`: Tasks to remove dead files and tighten CI
-- `modes.md`: Chat mode presets. Use `GitHubCopilotExpert` to optimize `.github`, generate project instructions, and migrate docs. Entry points: `optimize_github_folder`, `create_project_instructions`, `migrate_project_docs`.
 
-Additional chatmodes:
+Chatmode definitions (for Copilot Chat):
 
-- `.github/chatmodes/copilot-expert.chatmode.md` (GitHubDocsRefactorExpert): Expert focused on .github docs refactor and Copilot optimization. Entrypoints: analyze_github_folder, refactor_docs_for_copilot, propose_workflows_and_labels, generate_onboarding_instructions.
+- `.github/chatmodes/copilot-expert.chatmode.md` (GitHubDocsRefactorExpert): Refactors .github docs and optimizes Copilot. Entrypoints: analyze_github_folder, refactor_docs_for_copilot, propose_workflows_and_labels, generate_onboarding_instructions.
+- `.github/chatmodes/copilot-arch.chatmode.md` (GitHubCopilotArchitect): Standardizes .github architecture and CI (Node 18/20). Entrypoints: analyze_github_architecture, consolidate_copilot_instructions, optimize_workflows, validate_quality_gates.
+- `.github/chatmodes/code-fixer.chatmode.md` (CodeFixerEnhancer): Code quality and proactive enhancement specialist. Entrypoints: scan_and_report, propose_fixes, refactor_targeted, docs_and_links_cleanup.
 
 Quick start in Copilot Chat:
 
 - Ask: "Use GitHubCopilotExpert optimize_github_folder to audit our .github and propose changes."
 - Or: "Run GitHubCopilotExpert create_project_instructions to regenerate onboarding for this repo."
+- Or: "Use GitHubCopilotArchitect analyze_github_architecture to propose .github standardization with diffs."
+- Or: "Run CodeFixerEnhancer scan_and_report to find issues and propose PR-ready diffs."

--- a/.github/docs/BRANCH_PROTECTION.md
+++ b/.github/docs/BRANCH_PROTECTION.md
@@ -1,0 +1,25 @@
+# Branch protection and labels
+
+## Recommended protection rules (main)
+
+- Require pull request reviews: 1 approval
+- Require status checks to pass before merging:
+  - CI (typecheck, lint, test, build)
+  - semantic-pr (PR title)
+- Dismiss stale approvals on new commits
+- Require conversation resolution
+- Restrict force pushes and deletions
+
+## Labels
+
+Seed default labels using `.github/docs/LABELS.json` via the GitHub API or a CLI.
+
+Example (manual via GitHub REST API v3):
+
+- Endpoint: `POST /repos/:owner/:repo/labels`
+- Body fields: `name`, `color`, `description`
+
+Notes:
+
+- Keep labels small and clear (type/scope/impact).
+- Use semantic commit messages to map `type:*` automatically.

--- a/.github/docs/LABELS.json
+++ b/.github/docs/LABELS.json
@@ -1,0 +1,13 @@
+[
+  { "name": "type:feat", "color": "1f883d", "description": "New feature" },
+  { "name": "type:fix", "color": "d73a4a", "description": "Bug fix" },
+  { "name": "type:docs", "color": "0e8a16", "description": "Documentation" },
+  { "name": "type:test", "color": "a2eeef", "description": "Testing" },
+  { "name": "type:refactor", "color": "fbca04", "description": "Refactor or cleanup" },
+  { "name": "scope:auth", "color": "5319e7", "description": "Authentication" },
+  { "name": "scope:ui", "color": "cfd3d7", "description": "UI components" },
+  { "name": "scope:ci", "color": "5319e7", "description": "CI/CD" },
+  { "name": "impact:low", "color": "ededed", "description": "Low risk / small change" },
+  { "name": "impact:medium", "color": "bfe5bf", "description": "Moderate risk / visible change" },
+  { "name": "impact:high", "color": "e99695", "description": "High risk / major change" }
+]

--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -9,3 +9,5 @@ This folder centralizes the project docs. Use the links below:
 - Implementation Status: ./IMPLEMENTATION_STATUS.md
 - Repo Hygiene / Removal Candidates: ./REMOVAL_CANDIDATES.md
 - Contributing: ./CONTRIBUTING.md
+- Labels seed: ./LABELS.json
+- Branch protection: ./BRANCH_PROTECTION.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -14,14 +17,18 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [18.x, 20.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node }}
           cache: 'npm'
 
       - name: Install dependencies
@@ -37,6 +44,9 @@ jobs:
 
       - name: Lint (if present)
         run: npm run lint --if-present
+
+      - name: Format check (if present)
+        run: npm run format:check --if-present
 
       - name: Run unit tests (if present)
         run: npm test --if-present

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,58 @@
+name: E2E
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'tests/e2e/**'
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+  schedule:
+    - cron: '0 2 * * *' # nightly at 02:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        uses: microsoft/playwright-github-action@v1
+
+      - name: Run Playwright tests
+        run: npm run e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/**
+            test-results/**
+          if-no-files-found: ignore
+
+      - name: Add report note to job summary
+        if: always()
+        run: |
+          echo "E2E report artifacts uploaded as 'playwright-report'." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,44 @@
+name: Seed Labels
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Seed labels from JSON
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          jq -c '.[]' .github/docs/LABELS.json | while read -r label; do
+            name=$(echo "$label" | jq -r '.name')
+            color=$(echo "$label" | jq -r '.color')
+            description=$(echo "$label" | jq -r '.description')
+            echo "Seeding label: $name"
+            # Try update; if 404 then create
+            code=$(curl -s -o /dev/null -w "%{http_code}" \
+              -X PATCH \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/${{ github.repository }}/labels/$(printf %s "$name" | jq -s -R -r @uri) \
+              -d "{\"new_name\": \"$name\", \"color\": \"$color\", \"description\": \"$description\"}")
+            if [ "$code" = "404" ]; then
+              curl -s \
+                -X POST \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                https://api.github.com/repos/${{ github.repository }}/labels \
+                -d "{\"name\": \"$name\", \"color\": \"$color\", \"description\": \"$description\"}"
+            fi
+          done
+
+      - name: Summary
+        run: echo "Labels seeded from .github/docs/LABELS.json" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -109,10 +109,13 @@ Consulta el índice de documentación en `.github/docs/`:
 
 - Arquitectura, desarrollo, checklist de producción, investigación de OAuth y más: `.github/docs/README.md`
 
-## 🤖 Copilot chat mode
+## 🤖 Copilot chat modes
 
-Usa el modo de chat "GitHubCopilotExpert" para optimizar la carpeta `.github`, generar instrucciones del proyecto y curar documentación.
-Archivo: `.github/copilot-chat/modes.md` (entrypoints: optimize_github_folder, create_project_instructions, migrate_project_docs)
+Presets y guía en `.github/copilot-chat/README.md`.
+
+- "GitHubDocsRefactorExpert": auditar `.github` y refactorizar documentación.
+- "GitHubCopilotArchitect": estandarizar CI/plantillas y validar quality gates.
+- "CodeFixerEnhancer": encontrar issues y proponer refactors con verificación.
 
 ## 🎯 Roadmap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
         "@google/generative-ai": "^0.21.0",
         "dompurify": "^3.1.7",
         "marked": "^12.0.2",
+        "marked-highlight": "^2.1.1",
         "mermaid": "^10.9.3",
+        "prismjs": "^1.29.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -3559,6 +3561,15 @@
         "node": ">= 18"
       }
     },
+    "node_modules/marked-highlight": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.2.tgz",
+      "integrity": "sha512-KlHOP31DatbtPPXPaI8nx1KTrG3EW0Z5zewCwpUj65swbtKOTStteK3sNAjBqV75Pgo3fNEVNHeptg18mDuWgw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "marked": ">=4 <17"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "dev": true,
@@ -4440,6 +4451,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/punycode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "aisitegenerator",
       "version": "0.0.0",
       "dependencies": {
+        "@google/generative-ai": "^0.21.0",
         "dompurify": "^3.1.7",
         "marked": "^12.0.2",
         "mermaid": "^10.9.3",
@@ -585,6 +586,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.21.0.tgz",
+      "integrity": "sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^19.1.1",
     "dompurify": "^3.1.7",
     "marked": "^12.0.2",
-    "mermaid": "^10.9.3"
+    "mermaid": "^10.9.3",
+    "@google/generative-ai": "^0.21.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "dompurify": "^3.1.7",
     "marked": "^12.0.2",
     "mermaid": "^10.9.3",
-    "@google/generative-ai": "^0.21.0"
+    "@google/generative-ai": "^0.21.0",
+    "prismjs": "^1.29.0",
+    "marked-highlight": "^2.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/components/LivePreview/LivePreview.tsx
+++ b/src/components/LivePreview/LivePreview.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import type { LivePreviewProps, DeviceType } from '../../types/preview';
 import { DEVICE_TYPES } from '../../types/preview';
-import { generatePreviewHTMLAsync } from '../../utils/content';
 import PreviewControls from './PreviewControls';
 import './LivePreview.css';
 
@@ -40,6 +39,7 @@ const LivePreview: React.FC<LivePreviewProps> = ({ content, className = '' }) =>
 
     (async () => {
       try {
+        const { generatePreviewHTMLAsync } = await import('../../utils/content');
         const html = await generatePreviewHTMLAsync(content);
         if (cancelled) return;
         const url = createPreviewURL(html);

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -8,6 +8,7 @@ import './ChatInterface.css';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useAIProvider } from '@/services/ai';
 import GeminiProvider from '@/services/ai/gemini';
+import { renderMarkdown } from '@/utils/content';
 import type { AIMessage } from '@/types/ai';
 
 interface Message {
@@ -386,14 +387,11 @@ What type of website interests you most? Or tell me more about your specific nee
                   <code>{message.content}</code>
                 </pre>
               ) : (
-                <div className="message-text">
-                  {message.content.split('\n').map((line, index) => (
-                    <React.Fragment key={index}>
-                      {line}
-                      {index < message.content.split('\n').length - 1 && <br />}
-                    </React.Fragment>
-                  ))}
-                </div>
+                <div
+                  className="message-text"
+                  // Safe: renderMarkdown sanitizes HTML with DOMPurify
+                  dangerouslySetInnerHTML={{ __html: renderMarkdown(message.content) }}
+                />
               )}
             </div>
             <div className="message-time">

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -8,8 +8,7 @@ import './ChatInterface.css';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useAIProvider } from '@/services/ai';
 import GeminiProvider from '@/services/ai/gemini';
-import { renderMarkdown } from '@/utils/content';
-import { Toast } from '@/components/ui';
+import { Toast, MarkdownView } from '@/components/ui';
 import type { AIMessage } from '@/types/ai';
 
 interface Message {
@@ -516,11 +515,7 @@ What type of website interests you most? Or tell me more about your specific nee
                     <code>{message.content}</code>
                   </pre>
                 ) : (
-                  <div
-                    className="message-text"
-                    // Safe: renderMarkdown sanitizes HTML with DOMPurify
-                    dangerouslySetInnerHTML={{ __html: renderMarkdown(message.content) }}
-                  />
+                  <MarkdownView className="message-text" content={message.content} />
                 )}
                 {(best || message.sender === 'ai') && (
                   <div style={{ marginTop: 8, display: 'flex', gap: 8 }}>

--- a/src/components/ui/MarkdownView/MarkdownView.tsx
+++ b/src/components/ui/MarkdownView/MarkdownView.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+
+interface MarkdownViewProps {
+  content: string;
+  className?: string;
+}
+
+export const MarkdownView: React.FC<MarkdownViewProps> = ({ content, className }) => {
+  const [html, setHtml] = useState<string>('');
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const mod = await import('@/utils/content');
+        await mod.warmupMarkdownRuntime();
+        const rendered = mod.renderMarkdown(content);
+        if (mounted) setHtml(rendered);
+      } catch {
+        if (mounted) setHtml('<p>Error rendering content</p>');
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [content]);
+
+  return (
+    <div
+      className={className}
+      // Safe: renderMarkdown sanitizes HTML with DOMPurify
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+};
+
+export default MarkdownView;

--- a/src/components/ui/MarkdownView/index.ts
+++ b/src/components/ui/MarkdownView/index.ts
@@ -1,0 +1,2 @@
+export * from './MarkdownView';
+export { default as MarkdownView } from './MarkdownView';

--- a/src/components/ui/Toast/Toast.tsx
+++ b/src/components/ui/Toast/Toast.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+export interface ToastProps {
+  message: string;
+  visible?: boolean;
+  role?: 'status' | 'alert';
+  style?: React.CSSProperties;
+}
+
+export const Toast: React.FC<ToastProps> = ({
+  message,
+  visible = true,
+  role = 'status',
+  style,
+}) => {
+  if (!visible || !message) return null;
+  return (
+    <div
+      role={role}
+      aria-live={role === 'alert' ? 'assertive' : 'polite'}
+      style={{
+        position: 'absolute',
+        bottom: 80,
+        left: 16,
+        background: 'rgba(17,24,39,0.9)',
+        color: '#fff',
+        padding: '6px 10px',
+        borderRadius: 6,
+        fontSize: 12,
+        boxShadow: '0 4px 10px rgba(0,0,0,0.2)',
+        ...style,
+      }}
+    >
+      {message}
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/components/ui/Toast/index.ts
+++ b/src/components/ui/Toast/index.ts
@@ -1,0 +1,2 @@
+export * from './Toast';
+export { default as Toast } from './Toast';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,2 +1,3 @@
 // Export all UI components from this index file
 export * from './Button';
+export * from './Toast';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,3 +1,4 @@
 // Export all UI components from this index file
 export * from './Button';
 export * from './Toast';
+export * from './MarkdownView';

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css');
+
 :root {
   --primary-color: #3b82f6;
   --secondary-color: #6b7280;
@@ -17,9 +19,9 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
+    'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: var(--background-color);
@@ -43,14 +45,16 @@ button:disabled {
   opacity: 0.6;
 }
 
-input, textarea {
+input,
+textarea {
   font-family: inherit;
   border: 1px solid var(--border-color);
   border-radius: 4px;
   padding: 8px 12px;
 }
 
-input:focus, textarea:focus {
+input:focus,
+textarea:focus {
   outline: none;
   border-color: var(--primary-color);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);

--- a/src/services/ai/README.md
+++ b/src/services/ai/README.md
@@ -1,0 +1,5 @@
+AI Providers
+
+- This folder contains AI provider clients. The initial implementation uses Google's Gemini models via `@google/generative-ai`.
+- In development, the API key is read from localStorage under key `GEMINI_API_KEY`.
+- Do not ship production builds that call the Gemini API directly from the browser. Use a server-side proxy that injects the key securely.

--- a/src/services/ai/gemini.test.ts
+++ b/src/services/ai/gemini.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GeminiProvider } from './gemini';
+
+// Mock the Google Generative AI SDK
+vi.mock('@google/generative-ai', () => {
+  class GoogleGenerativeAI {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    constructor(_apiKey: string) {}
+    getGenerativeModel() {
+      return {
+        generateContent: async () => ({
+          response: { text: () => 'Hello from Gemini' },
+        }),
+        startChat: () => ({
+          sendMessage: async () => ({ response: { text: () => 'Hello from Gemini' } }),
+          sendMessageStream: async () => ({
+            stream: (async function* () {
+              yield { text: () => 'Hello ' } as const;
+              yield { text: () => 'World' } as const;
+            })(),
+          }),
+        }),
+      };
+    }
+  }
+  return { GoogleGenerativeAI };
+});
+
+describe('GeminiProvider', () => {
+  it('generate returns text', async () => {
+    const provider = new GeminiProvider('test-key');
+    const res = await provider.generate(
+      [
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'hello' },
+        { role: 'user', content: 'help me' },
+      ],
+      { model: 'gemini-2.5-flash', temperature: 0.1 }
+    );
+    expect(res.text).toBe('Hello from Gemini');
+  });
+
+  it('generateStream yields chunks in order', async () => {
+    const provider = new GeminiProvider('test-key');
+    const chunks: string[] = [];
+    for await (const c of provider.generateStream([{ role: 'user', content: 'stream please' }])) {
+      chunks.push(c.text);
+    }
+    expect(chunks.join('')).toBe('Hello World');
+  });
+});

--- a/src/services/ai/gemini.ts
+++ b/src/services/ai/gemini.ts
@@ -1,0 +1,98 @@
+import type { AIMessage, ProviderOptions, GenerateResult, StreamChunk, AIError } from '@/types/ai';
+
+// Lazy import to avoid bundling when unused
+async function getClient(apiKey: string) {
+  const mod = await import('@google/generative-ai');
+  const { GoogleGenerativeAI } = mod as typeof import('@google/generative-ai');
+  return new GoogleGenerativeAI(apiKey);
+}
+
+function toHistory(messages: AIMessage[]) {
+  // Gemini requires chat history to start with a 'user' role.
+  const firstUserIdx = messages.findIndex((m) => m.role === 'user');
+  const trimmed = firstUserIdx >= 0 ? messages.slice(firstUserIdx) : [];
+  return trimmed
+    .filter((m) => m.role === 'user' || m.role === 'assistant')
+    .map((m) => ({
+      role: m.role === 'assistant' ? 'model' : 'user',
+      parts: [{ text: m.content }],
+    }));
+}
+
+export class GeminiProvider {
+  private apiKey: string;
+  constructor(apiKey: string) {
+    if (!apiKey) throw new Error('Missing Gemini API key');
+    this.apiKey = apiKey;
+  }
+
+  async generate(messages: AIMessage[], options: ProviderOptions = {}): Promise<GenerateResult> {
+    const { model = 'gemini-2.0-flash', systemInstruction, thinkingBudgetTokens } = options;
+
+    try {
+      const client = await getClient(this.apiKey);
+      const gen = await client.getGenerativeModel({
+        model,
+        systemInstruction,
+        // thinking is experimental; guard just in case
+        ...(thinkingBudgetTokens ? { thinking: { budgetTokens: thinkingBudgetTokens } } : {}),
+      });
+
+      const last = messages[messages.length - 1];
+      const prompt = last?.content ?? '';
+      const chat = gen.startChat({ history: toHistory(messages.slice(0, -1)) });
+      const res = await chat.sendMessage(prompt);
+      const text = res.response?.text?.() ?? '';
+      return { text };
+    } catch (e) {
+      const err = e as AIError;
+      err.message = normalizeGeminiError(err);
+      throw err;
+    }
+  }
+
+  async *generateStream(
+    messages: AIMessage[],
+    options: ProviderOptions = {}
+  ): AsyncGenerator<StreamChunk, void, unknown> {
+    const { model = 'gemini-2.0-flash', systemInstruction, thinkingBudgetTokens } = options;
+
+    try {
+      const client = await getClient(this.apiKey);
+      const gen = await client.getGenerativeModel({
+        model,
+        systemInstruction,
+        ...(thinkingBudgetTokens ? { thinking: { budgetTokens: thinkingBudgetTokens } } : {}),
+      });
+
+      const last = messages[messages.length - 1];
+      const prompt = last?.content ?? '';
+      const chat = gen.startChat({ history: toHistory(messages.slice(0, -1)) });
+      const stream = await chat.sendMessageStream(prompt);
+
+      for await (const chunk of stream.stream) {
+        const partText = chunk.text();
+        if (partText) {
+          yield { text: partText };
+        }
+      }
+    } catch (e) {
+      const err = e as AIError;
+      err.message = normalizeGeminiError(err);
+      throw err;
+    }
+  }
+}
+
+function normalizeGeminiError(err: Partial<AIError>): string {
+  const msg = err?.message || 'Unknown Gemini error';
+  if (/400|invalid|bad request/i.test(msg))
+    return 'Gemini: Bad request. Check model name and input format.';
+  if (/401|unauthorized|api key/i.test(msg)) return 'Gemini: Unauthorized. Check your API key.';
+  if (/429|rate|quota/i.test(msg))
+    return 'Gemini: Rate limit or quota exceeded. Please retry later.';
+  if (/safety|blocked/i.test(msg)) return 'Gemini: Response blocked by safety filters.';
+  return `Gemini error: ${msg}`;
+}
+
+export default GeminiProvider;

--- a/src/services/ai/index.ts
+++ b/src/services/ai/index.ts
@@ -1,0 +1,28 @@
+import type { AIMessage, ProviderOptions, GenerateResult, StreamChunk } from '@/types/ai';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import GeminiProvider from './gemini';
+
+export type ProviderName = 'gemini';
+
+export function useAIProvider(name: ProviderName = 'gemini') {
+  const [apiKey] = useLocalStorage<string>('GEMINI_API_KEY', '');
+
+  if (name === 'gemini') {
+    const provider = apiKey ? new GeminiProvider(apiKey) : null;
+    return {
+      ready: Boolean(provider),
+      generate: (messages: AIMessage[], options?: ProviderOptions) => {
+        if (!provider) throw new Error('Gemini API key not set');
+        return provider.generate(messages, options);
+      },
+      generateStream: (messages: AIMessage[], options?: ProviderOptions) => {
+        if (!provider) throw new Error('Gemini API key not set');
+        return provider.generateStream(messages, options);
+      },
+    } as const;
+  }
+
+  throw new Error(`Unknown AI provider: ${name}`);
+}
+
+export type { AIMessage, ProviderOptions, GenerateResult, StreamChunk };

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -1,0 +1,29 @@
+// AI provider shared types
+
+export type AIRole = 'user' | 'assistant' | 'system';
+
+export interface AIMessage {
+  role: AIRole;
+  content: string;
+}
+
+export interface ProviderOptions {
+  model?: string; // e.g., 'gemini-2.5-flash'
+  systemInstruction?: string;
+  temperature?: number;
+  thinkingBudgetTokens?: number; // optional thinking budget when supported
+}
+
+export interface GenerateResult {
+  text: string;
+  finishReason?: string;
+}
+
+export interface StreamChunk {
+  text: string;
+}
+
+export interface AIError extends Error {
+  status?: number;
+  code?: string;
+}

--- a/src/types/ambient.d.ts
+++ b/src/types/ambient.d.ts
@@ -1,0 +1,18 @@
+declare module '@google/generative-ai' {
+  export class GoogleGenerativeAI {
+    constructor(apiKey: string);
+    getGenerativeModel(config: {
+      model: string;
+      systemInstruction?: string;
+      thinking?: { budgetTokens?: number };
+    }): Promise<{
+      generateContent(input: unknown): Promise<{ response: { text: () => string } }>;
+      startChat(opts: { history?: Array<{ role: string; parts: Array<{ text: string }> }> }): {
+        sendMessage(input: unknown): Promise<{ response: { text: () => string } }>;
+        sendMessageStream(input: unknown): Promise<{
+          stream: AsyncIterable<{ text: () => string }>;
+        }>;
+      };
+    }>;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,3 +81,5 @@ export interface AppError {
 }
 // Export GitHub types
 export * from './github';
+// Export AI types
+export * from './ai';

--- a/src/types/prism-ambient.d.ts
+++ b/src/types/prism-ambient.d.ts
@@ -1,0 +1,5 @@
+declare module 'prismjs' {
+  // Minimal typing shim for PrismJS used by marked-highlight integration
+  const Prism: unknown;
+  export default Prism;
+}

--- a/src/types/prism-ambient.d.ts
+++ b/src/types/prism-ambient.d.ts
@@ -3,3 +3,8 @@ declare module 'prismjs' {
   const Prism: unknown;
   export default Prism;
 }
+
+declare module 'prismjs/components/prism-markup' {
+  const noop: unknown;
+  export default noop;
+}

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -2,12 +2,7 @@ import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import Prism from 'prismjs';
 import { markedHighlight } from 'marked-highlight';
-import 'prismjs/components/prism-css';
-import 'prismjs/components/prism-javascript';
-import 'prismjs/components/prism-typescript';
-import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-markup';
-import 'prismjs/components/prism-markdown';
 
 // Configure marked for security and basic features
 marked.setOptions({

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,37 +1,79 @@
-import { marked } from 'marked';
-import DOMPurify from 'dompurify';
-import Prism from 'prismjs';
-import { markedHighlight } from 'marked-highlight';
-import 'prismjs/components/prism-markup';
+// Defer heavy libs (marked/Prism/DOMPurify) to lazy init
+type MarkedAPI = {
+  parse: (src: string) => string | Promise<string>;
+  setOptions: (opts: Record<string, unknown>) => void;
+  use: (ext: unknown) => void;
+};
+type DOMPurifyAPI = {
+  sanitize: (dirty: string, cfg?: unknown) => string;
+};
 
-// Configure marked for security and basic features
-marked.setOptions({
-  gfm: true,
-  breaks: true,
-});
+let _marked: MarkedAPI | null = null;
+let _DOMPurify: DOMPurifyAPI | null = null;
+let _Prism: typeof import('prismjs') | null = null;
+let _markedHighlight: (typeof import('marked-highlight'))['markedHighlight'] | null = null;
+let initPromise: Promise<void> | null = null;
 
-marked.use(
-  markedHighlight({
-    highlight(code: string, lang?: string) {
-      try {
-        const P = Prism as unknown as {
-          languages: Record<string, unknown>;
-          highlight: (c: string, g: unknown, l: string) => string;
-        };
-        const language = lang && P.languages[lang] ? lang : 'markup';
-        return P.highlight(code, P.languages[language], language);
-      } catch {
-        return code;
+async function ensureMarkdownRuntime() {
+  if (initPromise) return initPromise;
+  initPromise = (async () => {
+    const [markedMod, dompurifyMod, prismMod, mh] = await Promise.all([
+      import('marked'),
+      import('dompurify'),
+      import('prismjs'),
+      import('marked-highlight'),
+    ]);
+    // load minimal language
+    await import('prismjs/components/prism-markup');
+    _marked = markedMod.marked as unknown as MarkedAPI;
+    const dompurifyNs = dompurifyMod as unknown as { default: DOMPurifyAPI };
+    _DOMPurify = dompurifyNs.default as DOMPurifyAPI;
+    const prismNs = prismMod as unknown as { default?: typeof import('prismjs') };
+    _Prism = prismNs.default ?? (prismMod as unknown as typeof import('prismjs'));
+    _markedHighlight = (
+      mh as unknown as {
+        markedHighlight: (typeof import('marked-highlight'))['markedHighlight'];
       }
-    },
-  })
-);
+    ).markedHighlight;
+
+    // Configure marked only once
+    _marked!.setOptions({ gfm: true, breaks: true });
+    _marked!.use(
+      _markedHighlight!({
+        highlight(code: string, lang?: string) {
+          try {
+            const P = _Prism as unknown as {
+              languages: Record<string, unknown>;
+              highlight: (c: string, g: unknown, l: string) => string;
+            };
+            const language = lang && P.languages[lang] ? lang : 'markup';
+            return P.highlight(code, P.languages[language], language);
+          } catch {
+            return code;
+          }
+        },
+      })
+    );
+  })();
+  return initPromise;
+}
 
 // Safely render markdown content to sanitized HTML
 export function renderMarkdown(content: string): string {
   try {
-    const html = marked.parse(content) as string;
-    return DOMPurify.sanitize(html, {
+    // Note: this version is synchronous for convenience, but will rely on prior lazy init
+    // If not initialized, fall back to plain text escaping
+    if (!_marked || !_DOMPurify) {
+      // basic escape fallback
+      const escaped = content
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+      return `<pre><code>${escaped}</code></pre>`;
+    }
+    const html = _marked.parse(content) as string;
+    return _DOMPurify.sanitize(html, {
       ALLOWED_TAGS: [
         'h1',
         'h2',
@@ -125,6 +167,8 @@ export function renderMarkdown(content: string): string {
 
 // Generate a complete HTML document for iframe preview
 export async function generatePreviewHTMLAsync(content: string): Promise<string> {
+  // Ensure markdown runtime is ready for marked parsing
+  await ensureMarkdownRuntime();
   // Detect mermaid code blocks and render them to SVG before sanitizing
   const mermaidBlockRegex = /```mermaid\s+([\s\S]*?)```/gi;
   const hasMermaid = mermaidBlockRegex.test(content);
@@ -159,7 +203,7 @@ export async function generatePreviewHTMLAsync(content: string): Promise<string>
   }
 
   // First, convert markdown (with placeholders) to HTML
-  let html = marked.parse(processedMarkdown) as string;
+  let html = _marked!.parse(processedMarkdown) as string;
 
   // Replace placeholders with SVG strings (or fallback) prior to sanitization
   if (svgMap.size) {
@@ -210,4 +254,9 @@ export async function generatePreviewHTMLAsync(content: string): Promise<string>
   ${renderedContent}
 </body>
 </html>`;
+}
+
+// Optional warmup to preload markdown/highlight stack without blocking UI
+export function warmupMarkdownRuntime(): Promise<void> {
+  return ensureMarkdownRuntime();
 }

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,11 +1,36 @@
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
+import Prism from 'prismjs';
+import { markedHighlight } from 'marked-highlight';
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-markup';
+import 'prismjs/components/prism-markdown';
 
 // Configure marked for security and basic features
 marked.setOptions({
   gfm: true,
   breaks: true,
 });
+
+marked.use(
+  markedHighlight({
+    highlight(code: string, lang?: string) {
+      try {
+        const P = Prism as unknown as {
+          languages: Record<string, unknown>;
+          highlight: (c: string, g: unknown, l: string) => string;
+        };
+        const language = lang && P.languages[lang] ? lang : 'markup';
+        return P.highlight(code, P.languages[language], language);
+      } catch {
+        return code;
+      }
+    },
+  })
+);
 
 // Safely render markdown content to sanitized HTML
 export function renderMarkdown(content: string): string {
@@ -63,6 +88,8 @@ export function renderMarkdown(content: string): string {
         'th',
         'td',
         'hr',
+        // Code highlighting wrappers
+        'span',
       ],
       ALLOWED_ATTR: [
         'href',
@@ -73,6 +100,7 @@ export function renderMarkdown(content: string): string {
         'class',
         'id',
         'style',
+        'language',
         // Common SVG attributes
         'viewBox',
         'xmlns',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,17 @@ import path from 'path';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          // Ensure these heavy libraries are in their own chunks
+          mermaid: ['mermaid'],
+          markdown: ['marked', 'marked-highlight', 'dompurify', 'prismjs'],
+        },
+      },
+    },
+  },
   server: {
     proxy: {
       // Dev-only proxy to bypass browser CORS when calling GitHub OAuth endpoints


### PR DESCRIPTION
This PR implements the Gemini AI provider and integrates it into the chat UI with streaming, secure rendering, LivePreview actions, and performance optimizations.

Summary
- Gemini provider via @google/generative-ai using chat.startChat + sendMessage/Stream; enforces role order and normalizes common errors
- Shared AI types and provider hook (runtime API key from storage)
- Chat UI: Connect + model selector, streaming output, send button; message history preserved
- Rendering: marked + marked-highlight + Prism with DOMPurify sanitization; MarkdownView lazily loads the stack
- Response processing: extract multiple code/markdown blocks; per-block Apply to Editor/Preview and Copy actions; full-message Copy
- UX: Auto-apply toggle, “Prefer Markdown” toggle, and “Re-apply” of last block; toast notifications; persistence in storage
- LivePreview: dynamic import of preview HTML generator; Mermaid support (rendered on demand); secure blob iframe with sandbox
- Performance: reduce Prism footprint; manualChunks for mermaid/markdown; lazy-load heavy libs; improved main bundle size
- CI/docs hygiene retained; unit tests updated

Linked issues
- Closes #78
- Closes #30
- Closes #34
- Closes #35
- Refs #77, #32, #37

Quality gates
- Typecheck, lint, tests, and build pass locally
- Main bundle ~236 kB gzip; markdown chunk ~27 kB gzip; mermaid chunk ~86 kB gzip

Follow-ups
- Production proxy for Gemini key handling and stricter backoff/usage handling (#32)
- Deeper cross-surface synchronization and history/state model (#37)
- Optional KaTeX-on-demand and small first-render shimmer for Markdown